### PR TITLE
Fix a wrong method name and expose the upstream address as the variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ http {
             default_type text/html;
 
             rewrite_by_lua_block {
-                require("tracer"):start()
+                ------------------------------------------------------
+                -- NOTICE, this should be changed manually
+                -- This variable represents the upstream logic address
+                -- Please set them as service logic name or DNS name
+                --
+                -- TODO, currently, we ca not have the upstream real network address
+                ------------------------------------------------------
+                require("tracer"):start("upstream service")
             }
 
             -- Target upstream service

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ http {
                 -- This variable represents the upstream logic address
                 -- Please set them as service logic name or DNS name
                 --
-                -- TODO, currently, we ca not have the upstream real network address
+                -- Currently, we can not have the upstream real network address
                 ------------------------------------------------------
                 require("tracer"):start("upstream service")
             }

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -56,7 +56,7 @@ http {
                 -- This variable represents the upstream logic address
                 -- Please set them as service logic name or DNS name
                 --
-                -- TODO, currently, we ca not have the upstream real network address
+                -- Currently, we can not have the upstream real network address
                 ------------------------------------------------------
                 require("tracer"):start("upstream service")
             }

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -51,7 +51,14 @@ http {
             default_type text/html;
 
             rewrite_by_lua_block {
-                require("tracer"):startBackendTimer()
+                ------------------------------------------------------
+                -- NOTICE, this should be changed manually
+                -- This variable represents the upstream logic address
+                -- Please set them as service logic name or DNS name
+                --
+                -- TODO, currently, we ca not have the upstream real network address
+                ------------------------------------------------------
+                require("tracer"):start("upstream service")
             }
 
             proxy_pass http://127.0.0.1:8080/tier2/lb;

--- a/lib/skywalking/tracer.lua
+++ b/lib/skywalking/tracer.lua
@@ -17,7 +17,7 @@
 
 local Tracer = {}
 
-function Tracer:startBackendTimer()
+function Tracer:start(upstream_name)
     local metadata_buffer = ngx.shared.tracing_buffer
     local TC = require('tracing_context')
     local Layer = require('span_layer')
@@ -50,14 +50,8 @@ function Tracer:startBackendTimer()
     -- Use the same URI to represent incoming and forwarding requests
     -- Change it if you need.
     local upstreamUri = ngx.var.uri
-    ------------------------------------------------------
-    -- NOTICE, this should be changed manually
-    -- This variable represents the upstream logic address
-    -- Please set them as service logic name or DNS name
-    --
-    -- TODO, currently, we can't have the upstream real network address
-    ------------------------------------------------------
-    local upstreamServerName = serviceName .. "-nginx:upstream_ip:port"
+
+    local upstreamServerName = upstream_name
     ------------------------------------------------------
     local exitSpan = tracingContext:createExitSpan(upstreamUri, entrySpan, upstreamServerName, contextCarrier)
     exitSpan:start(ngx.now() * 1000)

--- a/test/e2e/validator/docker/conf.d/nginx.conf
+++ b/test/e2e/validator/docker/conf.d/nginx.conf
@@ -52,7 +52,7 @@ http {
             default_type text/html;
 
             rewrite_by_lua_block {
-                require("tracer"):startBackendTimer()
+                require("tracer"):start("User_Service_Name-nginx:upstream_ip:port")
             }
 
             proxy_pass http://127.0.0.1:8080/tier2/lb;

--- a/test/e2e/validator/docker/conf.d/nginx.conf
+++ b/test/e2e/validator/docker/conf.d/nginx.conf
@@ -70,7 +70,7 @@ http {
             default_type text/html;
 
             rewrite_by_lua_block {
-                require("tracer"):startBackendTimer()
+                require("tracer"):start("User_Service_Name-nginx:upstream_ip2:port2")
             }
 
             proxy_pass http://127.0.0.1:8080/backend;

--- a/test/e2e/validator/src/test/resources/expectedData.yaml
+++ b/test/e2e/validator/src/test/resources/expectedData.yaml
@@ -19,7 +19,7 @@ segmentItems:
             isError: false
             parentSpanId: 0
             componentId: 6000
-            peer: 'User_Service_Name-nginx:upstream_ip:port'
+            peer: 'User_Service_Name-nginx:upstream_ip2:port2'
             spanLayer: HTTP
           - operationName: /tier2/lb
             startTime: gt 0


### PR DESCRIPTION
1. Wrong method name. `Tracer:startBackendTimer` -> `Tracer:start(upstream_name)`
1. Upstream logic name should be set by the user to avoid there are several upstream clusters 