### PR TITLE
Add customer parameter for java agent config "agent.namespace"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Apache SkyWalking Nginx Agent With Customer Namespace
+Apache SkyWalking Nginx Agent
 ==========
 
 <img src="http://skywalking.apache.org/assets/logo.svg" alt="Sky Walking logo" height="90px" align="right" />

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ If you just use this in the Ngnix, [Setup Doc](#setup-doc) should be good enough
 The following APIs are for developers or using this lib out of the Nginx case.
 
 ## Nginx APIs
-- **startTimer**, `require("client"):startBackendTimer("http://127.0.0.1:8080")`. Start the backend timer. This timer register the metadata and report traces to the backend.
-- **start**, `require("tracer"):start("upstream service")`. Begin the tracing before the upstream begin.
+- **startTimer**, `require("client"):startBackendTimer("http://127.0.0.1:12800")`. Start the skywalking backend timer. This timer register the metadata and report traces to the backend.
+- **start**, `require("tracer"):start("upstream service", "agent_name_space")`. Begin the tracing before the upstream begin, use the name_space with java agent config "agent.namespace" .
 - **finish**, `require("tracer"):finish()`. Finish the tracing for this HTTP request.
 - **prepareForReport**, `require("tracer"):prepareForReport()`. Prepare the finished segment for further report.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Apache SkyWalking Nginx Agent
+Apache SkyWalking Nginx Agent With Customer Namespace
 ==========
 
 <img src="http://skywalking.apache.org/assets/logo.svg" alt="Sky Walking logo" height="90px" align="right" />
@@ -31,7 +31,7 @@ http {
         -- Instance means the number of Nginx deployment, does not mean the worker instances
         metadata_buffer:set('serviceInstanceName', 'User Service Instance Name')
 
-        require("client"):startBackendTimer("http://127.0.0.1:8080")
+        require("client"):startBackendTimer("http://127.0.0.1:12800")
     }
 
     server {
@@ -47,8 +47,9 @@ http {
                 -- Please set them as service logic name or DNS name
                 --
                 -- Currently, we can not have the upstream real network address
+                -- The parameter "customer_namespace" for java agent config "agent.namespace"
                 ------------------------------------------------------
-                require("tracer"):start("upstream service")
+                require("tracer"):start("upstream service", "customer_namespace")
             }
 
             -- Target upstream service

--- a/lib/skywalking/client.lua
+++ b/lib/skywalking/client.lua
@@ -119,7 +119,7 @@ function Client:registerServiceInstance(metadata_buffer, backend_http_uri)
     local DEBUG = ngx.DEBUG
     local ERR = ngx.ERR
 
-    local serviceInstName = 'name:' .. metadata_buffer:get('serviceInstanceName')
+    local serviceInstName = 'NAME:' .. metadata_buffer:get('serviceInstanceName')
     metadata_buffer:set('serviceInstanceUUID', serviceInstName)
 
     local cjson = require('cjson')

--- a/lib/skywalking/span.lua
+++ b/lib/skywalking/span.lua
@@ -65,12 +65,17 @@ local _M = {}
 
 -- Create an entry span. Represent the HTTP incoming request.
 -- @param contextCarrier, HTTP request header, which could carry the `sw6` context
-function _M.createEntrySpan(operationName, context, parent, contextCarrier)
+function _M.createEntrySpan(operationName, context, parent, contextCarrier, agent_name_space)
+    local nameSpace = ""
+    if agent_name_space ~= nil then
+        nameSpace = agent_name_space .. "-"
+    end
+
     local span = _M.new(operationName, context, parent)
     span.is_entry = true
 
     if contextCarrier ~= nil then
-        local propagatedContext = contextCarrier[CONTEXT_CARRIER_KEY]
+        local propagatedContext = contextCarrier[nameSpace .. CONTEXT_CARRIER_KEY]
         if propagatedContext ~= nil then
             local ref = SegmentRef.fromSW6Value(propagatedContext)
             if ref ~= nil then
@@ -86,7 +91,12 @@ function _M.createEntrySpan(operationName, context, parent, contextCarrier)
 end
 
 -- Create an exit span. Represent the HTTP outgoing request.
-function _M.createExitSpan(operationName, context, parent, peer, contextCarrier)
+function _M.createExitSpan(operationName, context, parent, peer, contextCarrier, agent_name_space)
+    local nameSpace = ""
+    if agent_name_space ~= nil then
+        nameSpace = agent_name_space .. "-"
+    end
+
     local span = _M.new(operationName, context, parent)
     span.is_exit = true
     span.peer = peer
@@ -137,7 +147,7 @@ function _M.createExitSpan(operationName, context, parent, peer, contextCarrier)
         injectableRef.parent_endpoint_name = parentEndpointName
         injectableRef.parent_endpoint_id = parentEndpointId
 
-        contextCarrier[CONTEXT_CARRIER_KEY] = SegmentRef.serialize(injectableRef)
+        contextCarrier[nameSpace .. CONTEXT_CARRIER_KEY] = SegmentRef.serialize(injectableRef)
     end
 
     return span

--- a/lib/skywalking/tracing_context.lua
+++ b/lib/skywalking/tracing_context.lua
@@ -124,22 +124,22 @@ end
 
 -- Delegate to Span.createEntrySpan
 -- @param contextCarrier could be nil if there is no downstream propagated context
-function _M.createEntrySpan(tracingContext, operationName, parent, contextCarrier)
+function _M.createEntrySpan(tracingContext, operationName, parent, contextCarrier, agent_name_space)
     if tracingContext.is_noop then
         return Span.newNoOP()
     end
 
-    return Span.createEntrySpan(operationName, tracingContext, parent, contextCarrier)
+    return Span.createEntrySpan(operationName, tracingContext, parent, contextCarrier, agent_name_space)
 end
 
 -- Delegate to Span.createExitSpan
 -- @param contextCarrier could be nil if don't need to inject any context to propagate
-function _M.createExitSpan(tracingContext, operationName, parent, peer, contextCarrier)
+function _M.createExitSpan(tracingContext, operationName, parent, peer, contextCarrier, agent_name_space)
     if tracingContext.is_noop then
         return Span.newNoOP()
     end
 
-    return Span.createExitSpan(operationName, tracingContext, parent, peer, contextCarrier)
+    return Span.createExitSpan(operationName, tracingContext, parent, peer, contextCarrier, agent_name_space)
 end
 
 -- After all active spans finished, this segment will be treated as finished status.


### PR DESCRIPTION
Add the customer parameter for java agent config "agent.namespace", so we can use the traceId from nginx to backend(java) server.