### PR TITLE
release a new version `0.3`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 0.3.0
+
+1. Load the `base64` module in `utils`, different ENV use different library.
+2. Add prefix `skywalking`, avoid conflicts with other lua libraries.
+3. Chore: only expose the method of setting random seed, it is optional.
+4. Coc: use correct code block type.
+5. CI: add upstream_status to tag http.status
+6. Add `http.status`
+
 ## 0.2.0
 
 1. Adapt the new v3 protocol.
@@ -11,6 +20,6 @@
 7. Uniform the SpanLayer type name.
 
 ## 0.1.0
+
 1. Establish the LUA tracing core.
 2. Add the tracer implementation based on Nginx OpenResty.
-

--- a/rockspec/skywalking-nginx-lua-0.2-1.rockspec
+++ b/rockspec/skywalking-nginx-lua-0.2-1.rockspec
@@ -1,8 +1,8 @@
 package = "skywalking-nginx-lua"
-version = "0.3-0"
+version = "0.2-1"
 source = {
    url = "git://github.com/apache/skywalking-nginx-lua",
-   tag = "v0.3",
+   tag = "v0.2.1",
 }
 
 description = {

--- a/rockspec/skywalking-nginx-lua-0.3-0.rockspec
+++ b/rockspec/skywalking-nginx-lua-0.3-0.rockspec
@@ -1,8 +1,8 @@
 package = "skywalking-nginx-lua"
-version = "master-0"
+version = "0.3-0"
 source = {
    url = "git://github.com/apache/skywalking-nginx-lua",
-   branch = "master",
+   tag = "v0.3",
 }
 
 description = {

--- a/rockspec/skywalking-nginx-lua-0.3-0.rockspec
+++ b/rockspec/skywalking-nginx-lua-0.3-0.rockspec
@@ -1,8 +1,8 @@
 package = "skywalking-nginx-lua"
-version = "0.2-1"
+version = "0.3-0"
 source = {
    url = "git://github.com/apache/skywalking-nginx-lua",
-   tag = "v0.2.1",
+   tag = "v0.3.0",
 }
 
 description = {


### PR DESCRIPTION
I think we can release a new version `0.2.1`.

We have updated the name style so it can be safely installed and used with other Lua libraries now.
