### PR TITLE
add flag to makesure Tracer:finish called

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.6.0
+
+1. fix: `skywalking_tracer:finish()` will not be called in some case such as upstream timeout.
+
 ## 0.5.0
 
 1. Adapt to Kong agent.

--- a/lib/skywalking/tracer.lua
+++ b/lib/skywalking/tracer.lua
@@ -79,7 +79,7 @@ function Tracer:start(upstream_name, correlation)
     ctx.tracingContext = tracingContext
     ctx.entrySpan = entrySpan
     ctx.exitSpan = exitSpan
-    ctx.is_called_finish = false
+    ctx.is_finished = false
 end
 
 function Tracer:finish()
@@ -92,11 +92,11 @@ function Tracer:finish()
         Span.finish(ngx.ctx.exitSpan, ngx.now() * 1000)
         ngx.ctx.exitSpan = nil
     end
-    ngx.ctx.is_called_finish = true
+    ngx.ctx.is_finished = true
 end
 
 function Tracer:prepareForReport()
-    if not ngx.ctx.is_called_finish then
+    if not ngx.ctx.is_finished then
         self.finish()
     end
     local entrySpan = ngx.ctx.entrySpan

--- a/lib/skywalking/tracer.lua
+++ b/lib/skywalking/tracer.lua
@@ -84,15 +84,15 @@ end
 
 function Tracer:finish()
     -- Finish the exit span when received the first response package from upstream
-    if ngx.ctx.exitSpan ~= nil then
+    if ngx.ctx.exitSpan ~= nil and not ngx.ctx.is_finished then
         local upstream_status = tonumber(ngx.var.upstream_status)
         if upstream_status then
             Span.tag(ngx.ctx.exitSpan, 'http.status', upstream_status)
         end
         Span.finish(ngx.ctx.exitSpan, ngx.now() * 1000)
         ngx.ctx.exitSpan = nil
+        ngx.ctx.is_finished = true
     end
-    ngx.ctx.is_finished = true
 end
 
 function Tracer:prepareForReport()

--- a/lib/skywalking/tracer.lua
+++ b/lib/skywalking/tracer.lua
@@ -79,6 +79,7 @@ function Tracer:start(upstream_name, correlation)
     ctx.tracingContext = tracingContext
     ctx.entrySpan = entrySpan
     ctx.exitSpan = exitSpan
+    ctx.is_called_finish = false
 end
 
 function Tracer:finish()
@@ -91,9 +92,13 @@ function Tracer:finish()
         Span.finish(ngx.ctx.exitSpan, ngx.now() * 1000)
         ngx.ctx.exitSpan = nil
     end
+    ngx.ctx.is_called_finish = true
 end
 
 function Tracer:prepareForReport()
+    if not ngx.ctx.is_called_finish then
+        self.finish()
+    end
     local entrySpan = ngx.ctx.entrySpan
     if not entrySpan then
         return


### PR DESCRIPTION
Fix about this issue.

https://github.com/apache/apisix/issues/4301

Add a flag to check whether the `Tracer:finish()` was called in the `body_by_lua_filter*` phase, if not, calling it in `log_by_lua*` phase.

