### PR TITLE
fix wrong forward port in example config.

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -74,7 +74,7 @@ http {
                 -- skywalking_tracer:start("upstream service", {custom = "custom_value"})
             }
 
-            proxy_pass http://127.0.0.1:8080/tier2/lb;
+            proxy_pass http://127.0.0.1:8090/tier2/lb;
 
             body_filter_by_lua_block {
                 if ngx.arg[2] then
@@ -94,7 +94,7 @@ http {
                 skywalking_tracer:start("backend service")
             }
 
-            proxy_pass http://127.0.0.1:8080/backend;
+            proxy_pass http://127.0.0.1:8090/backend;
 
             body_filter_by_lua_block {
                 if ngx.arg[2] then


### PR DESCRIPTION
change to the right listen port.

https://github.com/apache/skywalking-nginx-lua/blob/master/examples/nginx.conf#L59 listened `8090` port.
