### PR TITLE
support setting backend http uri after init worker stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ http {
         -- set random seed
         require("skywalking.util").set_randomseed()
         require("skywalking.client"):startBackendTimer("http://127.0.0.1:8080")
+        -- the backend url can also be set later, and just start backend timer:
+        -- require("skywalking.client"):startBackendTimer()
+        -- metadata_buffer:set('backendHttpUri', 'http://127.0.0.1:8080')
+        -- backendHttpUri can also be set in other places.
 
         -- If there is a bug of this `tablepool` implementation, we can
         -- disable it in this way

--- a/lib/skywalking/client.lua
+++ b/lib/skywalking/client.lua
@@ -42,14 +42,16 @@ function Client:startBackendTimer(backend_http_uri)
 
     check = function(premature)
         if not premature and not self.stopped then
-            local instancePropertiesSubmitted = metadata_buffer:get('instancePropertiesSubmitted')
-            if (instancePropertiesSubmitted == nil or instancePropertiesSubmitted == false) then
-                self:reportServiceInstance(metadata_buffer, backend_http_uri)
-            else
-                self:ping(metadata_buffer, backend_http_uri)
+            backend_http_uri = metadata_buffer:get('backendHttpUri') or backend_http_uri
+            if backend_http_uri ~= nil then
+                local instancePropertiesSubmitted = metadata_buffer:get('instancePropertiesSubmitted')
+                if (instancePropertiesSubmitted == nil or instancePropertiesSubmitted == false) then
+                    self:reportServiceInstance(metadata_buffer, backend_http_uri)
+                else
+                    self:ping(metadata_buffer, backend_http_uri)
+                end
+                self:reportTraces(metadata_buffer, backend_http_uri)
             end
-
-            self:reportTraces(metadata_buffer, backend_http_uri)
 
             -- do the health check
             local ok, err = new_timer(self.backendTimerDelay, check)


### PR DESCRIPTION
support setting backend http uri after init worker stage, then the the skywalking oap address can be configured dynamically.

