### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/test/e2e/e2e-test/pom.xml
+++ b/test/e2e/e2e-test/pom.xml
@@ -43,7 +43,7 @@
 
         <junit.version>4.11</junit.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.9.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <gson.version>2.8.6</gson.version>
         <guava.version>28.1-jre</guava.version>
         <lombok.version>1.18.10</lombok.version>


### PR DESCRIPTION
Hello new Patch!
Update log4j to 2.17.1 to address CVE-2021-44832.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832