### PR TITLE
stop reporting traces after the worker process begins to exit

### DIFF
--- a/lib/skywalking/client.lua
+++ b/lib/skywalking/client.lua
@@ -204,8 +204,13 @@ function Client:reportTraces(metadata_buffer, backend_http_uri)
         end
 
         segmentTransform = segmentTransform .. segment
-        segment = queue:rpop(Const.segment_queue)
         count = count + 1
+
+        if ngx.worker.exiting() then
+            break
+        end
+
+        segment = queue:rpop(Const.segment_queue)
 
         if count >= SEGMENT_BATCH_COUNT then
             if sendSegments('[' .. segmentTransform .. ']', backend_http_uri) then


### PR DESCRIPTION
The reporting task can slow down the worker process exiting if many traces are generated or the reporting rate slows down. In my case, the reporting task will slow down the reloading process, after the config or Lua code is updated.

