### PR TITLE
fix: allow timer to restart

### DIFF
--- a/lib/skywalking/client.lua
+++ b/lib/skywalking/client.lua
@@ -31,6 +31,7 @@ local initialized = false
 -- After report instance properties successfully, it sends keep alive packages.
 function Client:startBackendTimer(backend_http_uri)
     initialized = true
+    self.stopped = false
     local metadata_buffer = ngx.shared.tracing_buffer
 
     -- The codes of timer setup is following the OpenResty timer doc
@@ -42,6 +43,7 @@ function Client:startBackendTimer(backend_http_uri)
 
     check = function(premature)
         if not premature and not self.stopped then
+            log(ngx.INFO, "running timer")
             local instancePropertiesSubmitted = metadata_buffer:get('instancePropertiesSubmitted')
             if (instancePropertiesSubmitted == nil or instancePropertiesSubmitted == false) then
                 self:reportServiceInstance(metadata_buffer, backend_http_uri)

--- a/t/client.t
+++ b/t/client.t
@@ -114,3 +114,36 @@ true
 --- no_error_log
 language: lua
 Go keepAlive
+
+
+
+=== TEST 3: start backend timer then destory then restart backend timer
+--- config
+    location /t {
+        content_by_lua_block {
+            local client = require("skywalking.client")
+            client.backendTimerDelay = 0.1
+            client:startBackendTimer("http://127.0.0.1:" .. ngx.var.server_port)
+            ngx.sleep(0.1)
+            ngx.say('ok')
+
+            local ok, err = client:destroyBackendTimer()
+            if not err then
+                ngx.say(ok)
+            else
+                ngx.say(err)
+            end
+
+            client:startBackendTimer("http://127.0.0.1:" .. ngx.var.server_port)
+            ngx.sleep(0.1)
+            ngx.say('ok')
+        }
+    }
+--- response_body
+ok
+true
+ok
+--- error_log
+running timer
+running timer
+running timer

--- a/t/client.t
+++ b/t/client.t
@@ -143,7 +143,8 @@ Go keepAlive
 ok
 true
 ok
---- error_log
+--- grep_error_log: running timer
+--- grep_error_log_out
 running timer
 running timer
 running timer


### PR DESCRIPTION
The APISIX skywalking plugin reload creates a scenario where `destroyBackendTimer()` is called:

https://github.com/apache/apisix/blob/a478de8a586671bc7dd0dcf89d8db18d9913ab7c/apisix/plugins/skywalking.lua#L154

but after successful reload. When `startBackendTimer()` is called:

https://github.com/apache/apisix/blob/a478de8a586671bc7dd0dcf89d8db18d9913ab7c/apisix/plugins/skywalking.lua#L144

it won't succeed because `self.stopped` still remains `true`.

This issue has been fixed.